### PR TITLE
Fix addEnhancedEcommerceImpressionContext

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1572,14 +1572,15 @@ const parseEECObject = obj => {
   // Add an impression context for each impression in the hit
   if (getType(obj.impressions) === 'array') {
     obj.impressions.forEach(i => tracker('addEnhancedEcommerceImpressionContext',
-                                         i.id,
-                 				         i.name,
-				                         i.list,
-				                         i.brand,
-				                         i.category,
-				                         i.position,
-				                         i.price,
-				                         obj.currencyCode));
+									i.id,
+									i.name,
+									i.list,
+									i.brand,
+									i.category,
+									i.variant,
+									i.position,
+									i.price,
+									obj.currencyCode));
     action = 'view';
   }
   // Track promotion views for each promotion in the hit, as long as there isn't a promoClick in the object


### PR DESCRIPTION
Fixes #14 

Add all fields from the Snowplow tracker protocol: Variant was missing

https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracking-with-the-Javascript-tracker#3142-addenhancedecommerceimpressioncontext

